### PR TITLE
Center logo vertically in header banner

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -28,7 +28,7 @@ swMessaging.onBackgroundMessage((payload) => {
 });
 
 // ─── PWA caching ──────────────────────────────────────────────────────────────
-const CACHE = 'ironsynciq-v14';
+const CACHE = 'ironsynciq-v15';
 const ASSETS = [
     '/', '/index.html', '/styles.css', '/app.js', '/manifest.json',
     '/favicon-16x16.png', '/favicon-32x32.png', '/apple-touch-icon.png',

--- a/styles.css
+++ b/styles.css
@@ -178,6 +178,9 @@ header {
 }
 
 .logo {
+    display: flex;
+    align-items: center;
+    padding: 0 16px;
     font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
     font-size: 20px;
     font-weight: 800;


### PR DESCRIPTION
Added display:flex + align-items:center + padding to .logo so the wordmark is vertically centered within the sticky header on both mobile and desktop. Bumped SW cache to v15.

https://claude.ai/code/session_01FfgArpL8ZnmK62XtZZCcYR