### PR TITLE
Fix logo positioning and nav tab overlap

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -28,7 +28,7 @@ swMessaging.onBackgroundMessage((payload) => {
 });
 
 // ─── PWA caching ──────────────────────────────────────────────────────────────
-const CACHE = 'ironsynciq-v18';
+const CACHE = 'ironsynciq-v19';
 const ASSETS = [
     '/', '/index.html', '/styles.css', '/app.js', '/manifest.json',
     '/favicon-16x16.png', '/favicon-32x32.png', '/apple-touch-icon.png',

--- a/styles.css
+++ b/styles.css
@@ -179,10 +179,6 @@ header {
 }
 
 .logo {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
     display: flex;
     align-items: center;
     font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
@@ -193,6 +189,10 @@ header {
     text-transform: uppercase;
     white-space: nowrap;
     pointer-events: none;
+}
+
+header .logo {
+    padding: 0 20px;
 }
 
 .nav-tabs {


### PR DESCRIPTION
Remove position:absolute from .logo which was causing it to escape its container on auth/loading/role-selection screens and float to the viewport center. In the header the flex layout (space-between) keeps logo left and nav-tabs right with no overlap. Scoped header padding to header .logo only. Bump SW cache to v19.

https://claude.ai/code/session_01FfgArpL8ZnmK62XtZZCcYR