### PR TITLE
Add ECG heartbeat splash animation on startup

### DIFF
--- a/app.js
+++ b/app.js
@@ -152,7 +152,7 @@ onAuthStateChanged(auth, async (user) => {
             const wdSnap = await getDoc(doc(db, 'users', user.uid, 'data', 'workout_data'));
             if (!wdSnap.exists()) {
                 pendingRoleUid = user.uid;
-                document.getElementById('loading-screen').style.display = 'none';
+                hideLoadingScreen();
                 document.getElementById('auth-screen').style.display = 'none';
                 document.getElementById('role-selection-screen').style.display = 'flex';
             } else {
@@ -163,17 +163,30 @@ onAuthStateChanged(auth, async (user) => {
             currentUser = null;
             showAuthScreen();
         }
-    }, 1000);
+    }, 2900); // wait for ECG splash (0.35s delay + 2.1s draw + 0.35s fade-out = 2.8s)
 });
 
+let _splashDone = false;
+function hideLoadingScreen() {
+    const screen = document.getElementById('loading-screen');
+    if (!screen) return;
+    screen.style.display = 'none';
+    if (!_splashDone) {
+        _splashDone = true;
+        // Switch to lightweight spinner for any future shows (e.g. role-selection → app)
+        screen.classList.add('spinner-only');
+        screen.innerHTML = '<div class="loading-content"><div class="loading-spinner"></div></div>';
+    }
+}
+
 function showAuthScreen() {
-    document.getElementById('loading-screen').style.display = 'none';
+    hideLoadingScreen();
     document.getElementById('auth-screen').style.display = 'flex';
     document.getElementById('main-app').style.display = 'none';
 }
 
 function showMainApp() {
-    document.getElementById('loading-screen').style.display = 'none';
+    hideLoadingScreen();
     document.getElementById('auth-screen').style.display = 'none';
     document.getElementById('main-app').style.display = 'block';
     document.getElementById('admin-nav-tab').style.display = isAdmin() ? '' : 'none';

--- a/index.html
+++ b/index.html
@@ -18,13 +18,27 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <!-- Loading Screen -->
+    <!-- Splash / Loading Screen -->
     <div id="loading-screen" class="loading-screen">
-        <div class="loading-content">
-            <div class="logo" style="font-size: 48px; margin-bottom: 20px;">IRON<span style="color:var(--primary)">SYNC</span>IQ</div>
-            <div class="loading-spinner"></div>
-            <p style="color: var(--text-secondary); margin-top: 20px;">LOADING...</p>
+        <div class="splash-logo-wrap">
+            <div class="logo" style="font-size: 52px;">IRON<span style="color:#CC2428">SYNC</span>IQ</div>
+            <p class="splash-tagline">TRACK YOUR LIFTS</p>
         </div>
+        <!-- ECG heartbeat line — full viewport width -->
+        <svg class="ecg-svg" viewBox="0 0 1000 70" preserveAspectRatio="none" aria-hidden="true">
+            <!-- Baseline grid hint (very subtle) -->
+            <line class="ecg-grid" x1="0" y1="35" x2="1000" y2="35"/>
+            <!-- Animated ECG trace: flat → P wave → QRST complex → flat -->
+            <path class="ecg-path" pathLength="1"
+                  d="M 0,35 L 430,35 L 438,31 L 446,35 L 451,40 L 457,3 L 463,62 L 469,35 L 482,35 Q 499,16 516,35 L 1000,35"/>
+            <!-- Glowing leading dot -->
+            <circle class="ecg-dot" r="5">
+                <animate attributeName="opacity" values="0;1" dur="0.01s" begin="0.35s" fill="freeze"/>
+                <animate attributeName="opacity" values="1;0" dur="0.15s" begin="2.4s" fill="freeze"/>
+                <animateMotion dur="2.1s" begin="0.35s" fill="freeze" calcMode="linear"
+                    path="M 0,35 L 430,35 L 438,31 L 446,35 L 451,40 L 457,3 L 463,62 L 469,35 L 482,35 Q 499,16 516,35 L 1000,35"/>
+            </circle>
+        </svg>
     </div>
 
     <!-- Role Selection Screen (shown once, after first signup) -->

--- a/service-worker.js
+++ b/service-worker.js
@@ -28,7 +28,7 @@ swMessaging.onBackgroundMessage((payload) => {
 });
 
 // ─── PWA caching ──────────────────────────────────────────────────────────────
-const CACHE = 'ironsynciq-v21';
+const CACHE = 'ironsynciq-v22';
 const ASSETS = [
     '/', '/index.html', '/styles.css', '/app.js', '/manifest.json',
     '/favicon-16x16.png', '/favicon-32x32.png', '/apple-touch-icon.png',

--- a/styles.css
+++ b/styles.css
@@ -91,16 +91,100 @@ body {
    LOADING & AUTH SCREENS
    ═══════════════════════════════════════════ */
 
+/* ═══════════════════════════════════════════
+   SPLASH / LOADING SCREEN
+   ═══════════════════════════════════════════ */
+
 .loading-screen {
     position: fixed;
     inset: 0;
-    background: var(--bg-primary);
+    background: #000;
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 9999;
+    /* Auto-fade out after ECG finishes (0.35s draw delay + 2.1s draw = 2.45s; then 0.35s fade) */
+    animation: splashExit 0.35s ease 2.45s forwards;
 }
 
+/* When the splash has already played (spinner-only mode), suppress all splash animations */
+.loading-screen.spinner-only {
+    animation: none;
+    background: var(--bg-primary);
+}
+
+@keyframes splashExit {
+    to { opacity: 0; pointer-events: none; }
+}
+
+/* ── Logo entrance ── */
+.splash-logo-wrap {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    margin-bottom: 16px;
+    animation: splashLogoIn 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.splash-tagline {
+    color: rgba(235, 235, 235, 0.35);
+    font-family: 'Barlow Condensed', -apple-system, sans-serif;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 5px;
+    text-transform: uppercase;
+    margin: 6px 0 0;
+    padding: 0;
+}
+
+@keyframes splashLogoIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── ECG line ── */
+.ecg-svg {
+    position: absolute;
+    /* Sits just below center so the logo (above center) clears it */
+    top: calc(50% + 60px);
+    left: 0;
+    width: 100%;
+    height: 70px;
+    transform: translateY(-35px); /* vertically center the 70-unit viewBox */
+    overflow: visible;
+}
+
+.ecg-grid {
+    stroke: rgba(204, 36, 40, 0.12);
+    stroke-width: 1;
+}
+
+.ecg-path {
+    fill: none;
+    stroke: #CC2428;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    /* pathLength="1" on the element normalises the dash to total-path = 1 */
+    stroke-dasharray: 1;
+    stroke-dashoffset: 1;
+    animation: ecgDraw 2.1s linear 0.35s forwards;
+    filter: drop-shadow(0 0 5px rgba(204, 36, 40, 0.9))
+            drop-shadow(0 0 12px rgba(204, 36, 40, 0.4));
+}
+
+@keyframes ecgDraw {
+    to { stroke-dashoffset: 0; }
+}
+
+.ecg-dot {
+    fill: #CC2428;
+    opacity: 0; /* shown/hidden via SVG <animate> */
+    filter: drop-shadow(0 0 6px #CC2428)
+            drop-shadow(0 0 16px rgba(204, 36, 40, 0.6));
+}
+
+/* ── Fallback spinner (used after splash has played once) ── */
 .loading-content {
     text-align: center;
 }


### PR DESCRIPTION
Replaces the loading spinner with a full-screen heartbeat monitor animation on every page load:

- Black screen fades in the IRONSYNCIQ logo and tagline (0 → 0.35s)
- A red (#CC2428) ECG trace draws left-to-right across the full viewport width (0.35s → 2.45s), complete with subtle P wave, sharp QRST complex at screen center, smooth T wave, and a glowing leading dot that tracks the line tip
- Screen fades out (2.45s → 2.8s), then auth/app screen appears
- After the splash plays once, the loading screen is swapped to a lightweight spinner (no re-animation on subsequent shows such as returning from role-selection)
- onAuthStateChanged delay bumped to 2900ms to match animation

https://claude.ai/code/session_01FfgArpL8ZnmK62XtZZCcYR