### PR TITLE
Fix mobile header logo: vertical centering and larger size

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -28,7 +28,7 @@ swMessaging.onBackgroundMessage((payload) => {
 });
 
 // ─── PWA caching ──────────────────────────────────────────────────────────────
-const CACHE = 'ironsynciq-v24';
+const CACHE = 'ironsynciq-v25';
 const ASSETS = [
     '/', '/index.html', '/styles.css', '/app.js', '/manifest.json',
     '/favicon-16x16.png', '/favicon-32x32.png', '/apple-touch-icon.png',

--- a/styles.css
+++ b/styles.css
@@ -1946,12 +1946,14 @@ select.form-input:focus {
     /* ── Bottom navigation bar on mobile ── */
     .header-content {
         justify-content: center;
-        min-height: 50px;
+        align-items: center;
+        min-height: 56px;
     }
 
     /* Logo centered in top bar on mobile */
-    .logo {
-        font-size: 18px;
+    header .logo {
+        font-size: 22px;
+        padding: 0 16px;
     }
 
     /* Nav moves to a fixed bottom bar */


### PR DESCRIPTION
- Override align-items to center (was stretch) so logo sits in the middle of the header bar on mobile, not pinned to the top
- Increase font-size from 18px to 22px in the mobile breakpoint
- Bump min-height from 50px to 56px for a slightly more comfortable bar
- Bump service worker cache to v25

https://claude.ai/code/session_01FfgArpL8ZnmK62XtZZCcYR