### PR TITLE
Fix trainer linking, directory search, and account deletion

### DIFF
--- a/app.js
+++ b/app.js
@@ -214,7 +214,10 @@ async function loadUserRole() {
         // Lazy-migrate users who pre-date the role system.  Infer trainer
         // from the presence of a trainerProfile sub-object; fall back to
         // athlete.  Avoids silently overwriting real trainers as athletes.
-        if (!data.role) {
+        // Migrate users who either lack a role field or were incorrectly
+        // stamped 'athlete' by the old buggy migration (before this fix).
+        // A user with trainerProfile data was using trainer features → trainer.
+        if (!data.role || (data.role === 'athlete' && data.trainerProfile)) {
             const inferredRole = data.trainerProfile ? 'trainer' : 'athlete';
             await updateDoc(doc(db, 'users', currentUser.uid), { role: inferredRole });
             userRole = inferredRole;
@@ -425,9 +428,15 @@ async function performAccountDeletion(user) {
     try {
         await deleteDoc(doc(db, 'users', user.uid, 'data', 'workout_data'));
     } catch(e) { /* sub-doc may not exist */ }
-    await deleteDoc(doc(db, 'users', user.uid));
-    await deleteUser(user);
-    showToast('ACCOUNT DELETED', 'info');
+    try {
+        await deleteDoc(doc(db, 'users', user.uid));
+        await deleteUser(user);
+        showToast('ACCOUNT DELETED', 'info');
+    } catch(e) {
+        showToast('DELETE FAILED: ' + e.message, 'error');
+        console.error('performAccountDeletion error:', e);
+        throw e; // re-throw so callers can distinguish auth errors
+    }
 }
 
 async function updateProfileUI() {

--- a/firestore.rules
+++ b/firestore.rules
@@ -13,9 +13,60 @@ service cloud.firestore {
     match /users/{uid} {
       allow read: if request.auth != null;
       allow write: if request.auth != null && request.auth.uid == uid;
+      // A trainer can link themselves to an athlete by writing trainerId=their
+      // own uid.  The connection_requests flow provides consent at app level.
+      allow update: if request.auth != null
+        && request.resource.data.diff(resource.data).affectedKeys()
+             .hasOnly(['trainerId', 'trainerDisplayName'])
+        && request.resource.data.trainerId == request.auth.uid;
     }
     match /users/{uid}/{document=**} {
       allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
+
+    // ── Trainer ↔ Athlete connection requests ─────────────────────────
+    match /connection_requests/{reqId} {
+      allow read: if request.auth != null
+        && (resource.data.athleteId == request.auth.uid
+            || resource.data.trainerId == request.auth.uid);
+      // Either party may create a request naming themselves as athlete or trainer
+      allow create: if request.auth != null
+        && (request.resource.data.athleteId == request.auth.uid
+            || request.resource.data.trainerId == request.auth.uid);
+      // Either party may update (accept / decline) or delete
+      allow update: if request.auth != null
+        && (resource.data.athleteId == request.auth.uid
+            || resource.data.trainerId == request.auth.uid);
+      allow delete: if request.auth != null
+        && (resource.data.athleteId == request.auth.uid
+            || resource.data.trainerId == request.auth.uid);
+    }
+
+    // ── Trainer plan assignments ───────────────────────────────────────
+    match /trainer_assignments/{assignId} {
+      allow read: if request.auth != null
+        && (resource.data.athleteId == request.auth.uid
+            || resource.data.trainerId == request.auth.uid);
+      // Only the trainer can create an assignment
+      allow create: if request.auth != null
+        && request.resource.data.trainerId == request.auth.uid;
+      // Athlete can update status (accept/decline); either party can delete
+      allow update: if request.auth != null
+        && resource.data.athleteId == request.auth.uid;
+      allow delete: if request.auth != null
+        && (resource.data.athleteId == request.auth.uid
+            || resource.data.trainerId == request.auth.uid);
+    }
+
+    // ── Workout completion notifications ──────────────────────────────
+    match /workout_completions/{completionId} {
+      allow read: if request.auth != null
+        && (resource.data.athleteId == request.auth.uid
+            || resource.data.trainerId == request.auth.uid);
+      // Only the athlete who completed the workout can create the record
+      allow create: if request.auth != null
+        && request.resource.data.athleteId == request.auth.uid;
+      allow update, delete: if false;
     }
 
     // ── Community plans ───────────────────────────────────────────────


### PR DESCRIPTION
Three root causes fixed:

1. Role migration: also re-infer role when user was wrongly stamped 'athlete' by old code but has a trainerProfile object.  Previously the migration only ran when role was missing entirely, leaving any pre-role trainer who logged in with the old code permanently stuck as 'athlete' — causing the trainer directory to return 0 results.

2. Firestore rules: add rules for connection_requests, trainer_assignments, and workout_completions — all three collections were completely absent from the rules file (default deny), blocking every linking operation: sending invites, accepting requests, assigning plans, reading completions. Also add a trainer cross-write rule on /users/{uid} so a trainer can set trainerId=their own uid on an athlete's document (required by acceptConnectionRequest) without full owner-write permission.

3. Account deletion: wrap the Firestore + Auth delete sequence in a try/catch so errors surface as visible toasts instead of being swallowed by the caller's generic 'AUTHENTICATION FAILED' message.

https://claude.ai/code/session_01FfgArpL8ZnmK62XtZZCcYR